### PR TITLE
最新のEvolved Mekanism Extrasに対応

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -355,7 +355,7 @@ val mainModDependencies = baseDependencies.toMutableList().apply {
     add(ModDep("mekanismelements", "2.3", ordering = Order.AFTER, mandatory = false))
     add(ModDep("mekanism_extras", "1.20.1-1.4.6", ordering = Order.AFTER, mandatory = false))
     add(ModDep("mekmm", "1.1.0", ordering = Order.AFTER, mandatory = false))
-    add(ModDep("emextras", "1.3.3", ordering = Order.AFTER, mandatory = false))
+    add(ModDep("emextras", "1.3.5", ordering = Order.AFTER, mandatory = false))
     add(ModDep("mekanismtweaks", "999.999.999-INCOMPATIBLE", false))
     add(ModDep("mekanismupgradesreborn", "999.999.999-INCOMPATIBLE", false))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ igleelib = "6987117" # 1.2.7
 evolvedMekanism = "7161181" # 1.2.1
 mekanismElements = "6537553" # 2.3
 mekanismMoreMachines = "7316932" # 1.1.0
-evolvedMekanismExtras = "6866367" # 1.3.3
+evolvedMekanismExtras = "7466728" # 1.3.5
 
 
 [libraries]

--- a/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMekExt.kt
+++ b/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMekExt.kt
@@ -9,6 +9,7 @@ import io.github.masyumero.emextras.common.content.blocktype.EMExtraFactoryType
 import io.github.masyumero.emextras.common.registry.EMExtrasBlockType
 import io.github.masyumero.emextras.common.util.EMExtraEnumUtils
 import mekanism.api.Upgrade
+import mekanism.common.content.blocktype.FactoryType
 
 
 internal object EvoMekExt : ModIntegration {
@@ -26,18 +27,18 @@ internal object EvoMekExt : ModIntegration {
         addSupportedFactoryUpgrades(EMExtraFactoryType.INFUSING, *ITEM_IN_OUT_MACHINE_UPGRADES)
         addSupportedFactoryUpgrades(EMExtraFactoryType.PURIFYING, *ITEM_IN_OUT_MACHINE_UPGRADES)
         addSupportedFactoryUpgrades(EMExtraFactoryType.INJECTING, *ITEM_IN_OUT_MACHINE_UPGRADES)
+        addSupportedFactoryUpgrades(EMFactoryType.ALLOYING, *ITEM_IN_OUT_MACHINE_UPGRADES)
     }
 
     private fun addSupportedFactoryUpgrades(type: EMExtraFactoryType, vararg upgrades: Upgrade) {
         for (tier in EMExtraEnumUtils.EMEXTRA_FACTORY_TIERS) {
-            if (type == EMExtraFactoryType.ADVANCED_ALLOYING) {
-                continue
-            }
-
             AdditionalUpgradeUtil.addSupported(EMExtrasBlockType.getEMExtraFactory(tier, type), *upgrades)
         }
+    }
+
+    private fun addSupportedFactoryUpgrades(type: FactoryType, vararg upgrades: Upgrade) {
         for (tier in ExtraEnumUtils.ADVANCED_FACTORY_TIERS) {
-            AdditionalUpgradeUtil.addSupported(EMExtrasBlockType.getAdvancedFactory(tier, EMFactoryType.ALLOYING), *upgrades)
+            AdditionalUpgradeUtil.addSupported(EMExtrasBlockType.getAdvancedFactory(tier, type), *upgrades)
         }
     }
 }

--- a/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMekExt.kt
+++ b/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMekExt.kt
@@ -1,8 +1,10 @@
 package dev.lapis256.mekanism_empowered.integration.mods
 
+import com.jerry.mekanism_extras.common.util.ExtraEnumUtils
 import dev.lapis256.mekanism_empowered.common.init.MekEmpUpgrades.ITEM_IN_OUT_MACHINE_UPGRADES
 import dev.lapis256.mekanism_empowered.core.common.util.AdditionalUpgradeUtil
 import dev.lapis256.mekanism_empowered.integration.ModIntegration
+import fr.iglee42.evolvedmekanism.registries.EMFactoryType
 import io.github.masyumero.emextras.common.content.blocktype.EMExtraFactoryType
 import io.github.masyumero.emextras.common.registry.EMExtrasBlockType
 import io.github.masyumero.emextras.common.util.EMExtraEnumUtils
@@ -28,11 +30,14 @@ internal object EvoMekExt : ModIntegration {
 
     private fun addSupportedFactoryUpgrades(type: EMExtraFactoryType, vararg upgrades: Upgrade) {
         for (tier in EMExtraEnumUtils.EMEXTRA_FACTORY_TIERS) {
-            if (type != EMExtraFactoryType.ALLOYING && !tier.isEvolved) {
+            if (type == EMExtraFactoryType.ADVANCED_ALLOYING) {
                 continue
             }
 
             AdditionalUpgradeUtil.addSupported(EMExtrasBlockType.getEMExtraFactory(tier, type), *upgrades)
+        }
+        for (tier in ExtraEnumUtils.ADVANCED_FACTORY_TIERS) {
+            AdditionalUpgradeUtil.addSupported(EMExtrasBlockType.getAdvancedFactory(tier, EMFactoryType.ALLOYING), *upgrades)
         }
     }
 }


### PR DESCRIPTION
Evolved Mekanism Extras 1.3.5以降の[EMExtraFactoryTier](https://github.com/masyumero/EvolvedMekanismExtras/blob/master/src/main/java/io/github/masyumero/emextras/common/tier/EMExtraFactoryTier.java)クラスからはisEvolved()メソッドが削除されているので使用箇所を修正しました