### PR TITLE
fix: lazy initialize EvoMek FACTORY_TIERS to prevent crash without mod

### DIFF
--- a/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMek.kt
+++ b/src/main/kotlin/dev/lapis256/mekanism_empowered/integration/mods/EvoMek.kt
@@ -23,7 +23,9 @@ internal object EvoMek : ModIntegration {
         AdditionalUpgradeUtil.addSupported(EMBlockTypes.SOLIDIFIER, *ITEM_IN_OUT_MACHINE_UPGRADES)
     }
 
-    val FACTORY_TIERS = arrayOf(EMFactoryTier.OVERCLOCKED, EMFactoryTier.QUANTUM, EMFactoryTier.DENSE, EMFactoryTier.MULTIVERSAL, EMFactoryTier.CREATIVE)
+    val FACTORY_TIERS by lazy {
+        arrayOf(EMFactoryTier.OVERCLOCKED, EMFactoryTier.QUANTUM, EMFactoryTier.DENSE, EMFactoryTier.MULTIVERSAL, EMFactoryTier.CREATIVE)
+    }
 
     override fun initProvider(registry: IntegrationProviderRegistry) {
         registry.registerProvider(FactoryUpgradeIntegration { type, upgrades ->


### PR DESCRIPTION
fix #29 
